### PR TITLE
Added whitespace after semicolon

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,7 +183,7 @@ gulp.task('sync', ['serve'], function(cb) {
   });
 
   gulp.watch(['build/**/*.*'].concat(
-    src.server.map(function(file) {return '!' + file;})
+    src.server.map(function(file) {return '!' + file; })
   ), function(file) {
     browserSync.reload(path.relative(__dirname, file.path));
   });


### PR DESCRIPTION
Without this, `npm test` would fail.